### PR TITLE
Added example_methods configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `example_methods` as a configuration option to add your own example methods
+
 Add here...
 
 ## v0.2.2 - 2024-06-23

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ rspec:
     - let_it_be
 ```
 
+If you have your own custom `example`-like methods like `it`, you can add them to your `.solargraph.yml` file like this:
+
+```yaml
+# .solargraph.yml
+# ...
+rspec:
+  example_methods:
+    - my_it
+```
+
 ### Gem completions
 
 Solargraph utilizes the YARD documentation to provide code completion. If you want to have completion for gems in your project, you can generate YARD documentation for them ([Read more](https://solargraph.org/guides/yard)).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ rspec:
     - my_it
 ```
 
+This is useful if you use gems like [rspec-given](https://github.com/rspec-given/rspec-given) which introduces its own `let` and `example` methods.
+
+
 ### Gem completions
 
 Solargraph utilizes the YARD documentation to provide code completion. If you want to have completion for gems in your project, you can generate YARD documentation for them ([Read more](https://solargraph.org/guides/yard)).

--- a/lib/solargraph/rspec/config.rb
+++ b/lib/solargraph/rspec/config.rb
@@ -20,6 +20,11 @@ module Solargraph
         (Rspec::LET_METHODS + additional_let_methods).map(&:to_sym)
       end
 
+      # @return [Array<Symbol>]
+      def example_methods
+        (Rspec::EXAMPLE_METHODS + additional_example_methods).map(&:to_sym)
+      end
+
       private
 
       # @return [Hash]
@@ -30,6 +35,11 @@ module Solargraph
       # @return [Array<Symbol>]
       def additional_let_methods
         (rspec_raw_data['let_methods'] || []).map(&:to_sym)
+      end
+
+      # @return [Array<Symbol>]
+      def additional_example_methods
+        (rspec_raw_data['example_methods'] || []).map(&:to_sym)
       end
 
       # @return [Hash]

--- a/lib/solargraph/rspec/spec_walker.rb
+++ b/lib/solargraph/rspec/spec_walker.rb
@@ -138,7 +138,7 @@ module Solargraph
         end
 
         walker.on :ITER do |block_ast|
-          next unless NodeTypes.a_example_block?(block_ast)
+          next unless NodeTypes.a_example_block?(block_ast, config)
 
           @handlers[:on_example_block].each do |handler|
             handler.call(PinFactory.build_location_range(block_ast))

--- a/lib/solargraph/rspec/spec_walker/node_types.rb
+++ b/lib/solargraph/rspec/spec_walker/node_types.rb
@@ -25,9 +25,10 @@ module Solargraph
         end
 
         # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param config [Config]
         # @return [Boolean]
-        def self.a_example_block?(block_ast)
-          Solargraph::Rspec::EXAMPLE_METHODS.include?(method_with_block_name(block_ast))
+        def self.a_example_block?(block_ast, config)
+          config.example_methods.map(&:to_s).include?(method_with_block_name(block_ast))
         end
 
         # @param ast [RubyVM::AbstractSyntaxTree::Node]

--- a/spec/solargraph/rspec/spec_walker/node_types_spec.rb
+++ b/spec/solargraph/rspec/spec_walker/node_types_spec.rb
@@ -57,20 +57,21 @@ RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
   end
 
   describe '.a_example_block?' do
+    let(:config) { Solargraph::Rspec::Config.new }
+
     it 'returns true for example block with name' do
       node = parse('it("does something") { }')
-      expect(described_class.a_example_block?(node.children[2])).to be(true)
+      expect(described_class.a_example_block?(node.children[2], config)).to be(true)
     end
 
     it 'returns true for example block without name' do
       node = parse('it { }')
-
-      expect(described_class.a_example_block?(node.children[2])).to be(true)
+      expect(described_class.a_example_block?(node.children[2], config)).to be(true)
     end
 
     it 'returns false for non-example block' do
       node = parse('non_example { }')
-      expect(described_class.a_example_block?(node.children[2])).to be(false)
+      expect(described_class.a_example_block?(node.children[2], config)).to be(false)
     end
   end
 


### PR DESCRIPTION
Adds the `example_methods` to define your own example methods.

Fixes https://github.com/lekemula/solargraph-rspec/issues/5

## Test guide

Install a local version of the gem in a project that uses solargraph and rspec.

Configure rspec in your `.solargraph.yml` configuration file like so

```yaml
rspec:
  example_methods:
    - my_it
```

Open a spec file and add something like this:
```ruby
  describe "something" do
    let(:foobar){"hello"}

    my_it do
      expect(foobar).to eq "hello"
    end

    it do
      expect(foobar).to eq "hello"
    end
  end
```

The behavior should be equivalent. Go-to-definition etc should work like expected.
