### PR TITLE
Use solargraph's parser

### DIFF
--- a/lib/solargraph/rspec/correctors/let_methods_corrector.rb
+++ b/lib/solargraph/rspec/correctors/let_methods_corrector.rb
@@ -23,7 +23,7 @@ module Solargraph
 
         # @param namespace [Pin::Namespace]
         # @param method_name [String]
-        # @param node [RubyVM::AbstractSyntaxTree::Node]
+        # @param node [::Parser::AST::Node, nil]
         # @param types [Array<String>, nil]
         # @return [Pin::Method, nil]
         def rspec_let_method(namespace, method_name, location_range, node = nil, types: nil)

--- a/lib/solargraph/rspec/pin_factory.rb
+++ b/lib/solargraph/rspec/pin_factory.rb
@@ -74,16 +74,10 @@ module Solargraph
         )
       end
 
-      # @param ast [RubyVM::AbstractSyntaxTree::Node]
-      # @see [RubyVM::AbstractSyntaxTree::NodeWrapper] - for why we need -1 for lineno
+      # @param ast [::Parser::AST::Node]
       # @return [Solargraph::Range]
       def self.build_location_range(ast)
-        Solargraph::Range.from_to(
-          ast.first_lineno - 1,
-          ast.first_column,
-          ast.last_lineno - 1,
-          ast.last_column
-        )
+        Solargraph::Parser.node_range(ast)
       end
 
       # @param location_range [Solargraph::Range]

--- a/lib/solargraph/rspec/spec_walker.rb
+++ b/lib/solargraph/rspec/spec_walker.rb
@@ -119,7 +119,7 @@ module Solargraph
           method_name = NodeTypes.let_method_name(block_ast)
           next unless method_name
 
-          fake_method_ast = FakeLetMethod.transform_block(block_ast, @source_map.source.code, method_name)
+          fake_method_ast = FakeLetMethod.transform_block(block_ast, method_name)
 
           @handlers[:on_let_method].each do |handler|
             handler.call(method_name, PinFactory.build_location_range(block_ast.children[0]), fake_method_ast)
@@ -130,7 +130,7 @@ module Solargraph
           next unless NodeTypes.a_subject_block?(block_ast)
 
           method_name = NodeTypes.let_method_name(block_ast)
-          fake_method_ast = FakeLetMethod.transform_block(block_ast, @source_map.source.code, method_name || 'subject')
+          fake_method_ast = FakeLetMethod.transform_block(block_ast, method_name || 'subject')
 
           @handlers[:on_subject].each do |handler|
             handler.call(method_name, PinFactory.build_location_range(block_ast.children[0]), fake_method_ast)

--- a/lib/solargraph/rspec/spec_walker.rb
+++ b/lib/solargraph/rspec/spec_walker.rb
@@ -14,8 +14,7 @@ module Solargraph
       def initialize(source_map:, config:)
         @source_map = source_map
         @config = config
-        # TODO: Implement SpecWalker with parser gem using default AST from `source_map.source.node`
-        @walker = Rspec::Walker.new(ruby_vm_node(source_map))
+        @walker = Rspec::Walker.new(source_map.source.node)
         @handlers = {
           on_described_class: [],
           on_let_method: [],
@@ -45,7 +44,7 @@ module Solargraph
       # @param block [Proc]
       # @yieldparam method_name [String]
       # @yieldparam location_range [Solargraph::Range]
-      # @yieldparam fake_method_ast [RubyVM::AbstractSyntaxTree::Node]
+      # @yieldparam fake_method_ast [::Parser::AST::Node]
       # @return [void]
       def on_let_method(&block)
         @handlers[:on_let_method] << block
@@ -54,7 +53,7 @@ module Solargraph
       # @param block [Proc]
       # @yieldparam method_name [String]
       # @yieldparam location_range [Solargraph::Range]
-      # @yieldparam fake_method_ast [RubyVM::AbstractSyntaxTree::Node]
+      # @yieldparam fake_method_ast [::Parser::AST::Node]
       # @return [void]
       def on_subject(&block)
         @handlers[:on_subject] << block
@@ -114,7 +113,7 @@ module Solargraph
           end
         end
 
-        walker.on :ITER do |block_ast|
+        walker.on :block do |block_ast|
           next unless NodeTypes.a_let_block?(block_ast, config)
 
           method_name = NodeTypes.let_method_name(block_ast)
@@ -127,7 +126,7 @@ module Solargraph
           end
         end
 
-        walker.on :ITER do |block_ast|
+        walker.on :block do |block_ast|
           next unless NodeTypes.a_subject_block?(block_ast)
 
           method_name = NodeTypes.let_method_name(block_ast)
@@ -138,30 +137,30 @@ module Solargraph
           end
         end
 
-        walker.on :ITER do |block_ast|
+        walker.on :block do |block_ast|
           next unless NodeTypes.a_example_block?(block_ast, config)
 
           @handlers[:on_example_block].each do |handler|
             handler.call(PinFactory.build_location_range(block_ast))
           end
 
-          # @param blocks_in_examples [RubyVM::AbstractSyntaxTree::Node]
-          each_block(block_ast.children[1]) do |blocks_in_examples|
+          # @param blocks_in_examples [::Parser::AST::Node]
+          each_block(block_ast.children[2]) do |blocks_in_examples|
             @handlers[:on_blocks_in_examples].each do |handler|
               handler.call(PinFactory.build_location_range(blocks_in_examples))
             end
           end
         end
 
-        walker.on :ITER do |block_ast|
+        walker.on :block do |block_ast|
           next unless NodeTypes.a_hook_block?(block_ast)
 
           @handlers[:on_hook_block].each do |handler|
             handler.call(PinFactory.build_location_range(block_ast))
           end
 
-          # @param blocks_in_examples [RubyVM::AbstractSyntaxTree::Node]
-          each_block(block_ast.children[1]) do |blocks_in_examples|
+          # @param blocks_in_examples [::Parser::AST::Node]
+          each_block(block_ast.children[2]) do |blocks_in_examples|
             @handlers[:on_blocks_in_examples].each do |handler|
               handler.call(PinFactory.build_location_range(blocks_in_examples))
             end
@@ -178,11 +177,9 @@ module Solargraph
       # @param ast [Parser::AST::Node]
       # @param parent_result [Object]
       def each_block(ast, parent_result = nil, &block)
-        return unless ast.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        return nil unless ast.is_a?(::Parser::AST::Node)
 
-        is_a_block = NodeTypes.a_block?(ast)
-
-        if is_a_block
+        if NodeTypes.a_block?(ast)
           result = block&.call(ast, parent_result)
           parent_result = result if result
         end
@@ -210,12 +207,6 @@ module Solargraph
           block&.call(namespace_name, block_ast)
           next parent_namespace
         end
-      end
-
-      # @param source_map [SourceMap]
-      # @return [RubyVM::AbstractSyntaxTree::Node]
-      def ruby_vm_node(source_map)
-        RubyVM::AbstractSyntaxTree.parse(source_map.source.code)
       end
     end
   end

--- a/lib/solargraph/rspec/spec_walker/fake_let_method.rb
+++ b/lib/solargraph/rspec/spec_walker/fake_let_method.rb
@@ -9,30 +9,18 @@ module Solargraph
 
         class << self
           # Transforms let block to method ast node
-          # @param block_ast [RubyVM::AbstractSyntaxTree::Node]
+          # @param block_ast [::Parser::AST::Node]
           # @param code [String] code
           # @return [::Parser::AST::Node, nil]
           def transform_block(block_ast, code, method_name = nil)
             method_name ||= NodeTypes.let_method_name(block_ast)
 
-            code_lines = code.split("\n")
-            # extract let definition block body code
-            first_line = code_lines[block_ast.first_lineno - 1]
-            last_line = code_lines[block_ast.last_lineno - 1]
-            code_lines[block_ast.first_lineno - 1] = first_line[(block_ast.first_column)..]
-            code_lines[block_ast.last_lineno - 1] = last_line[0..(block_ast.last_column)]
-            let_definition_code = code_lines[
-              (block_ast.first_lineno - 1)..(block_ast.last_lineno - 1)
-            ].join("\n")
-
-            let_definition_ast = Solargraph::Parser.parse(let_definition_code)
-            method_body = let_definition_ast.children[2]
             ::Parser::AST::Node.new( # transform let block to a method ast node
               :def,
               [
                 method_name.to_sym,
                 ::Parser::AST::Node.new(:args, []),
-                method_body
+                block_ast.children[2]
               ]
             )
           rescue SyntaxError => e

--- a/lib/solargraph/rspec/spec_walker/fake_let_method.rb
+++ b/lib/solargraph/rspec/spec_walker/fake_let_method.rb
@@ -10,9 +10,8 @@ module Solargraph
         class << self
           # Transforms let block to method ast node
           # @param block_ast [::Parser::AST::Node]
-          # @param code [String] code
           # @return [::Parser::AST::Node, nil]
-          def transform_block(block_ast, code, method_name = nil)
+          def transform_block(block_ast, method_name = nil)
             method_name ||= NodeTypes.let_method_name(block_ast)
 
             ::Parser::AST::Node.new( # transform let block to a method ast node

--- a/lib/solargraph/rspec/spec_walker/full_constant_name.rb
+++ b/lib/solargraph/rspec/spec_walker/full_constant_name.rb
@@ -5,17 +5,24 @@ module Solargraph
     class SpecWalker
       class FullConstantName
         class << self
-          # @param ast [RubyVM::AbstractSyntaxTree::Node]
+          # @param ast [::Parser::AST::Node]
           # @return [String]
           def from_ast(ast)
-            raise 'Node is not a constant' unless NodeTypes.a_constant?(ast)
+            parts = []
 
-            if ast.type == :CONST
-              ast.children[0].to_s
-            elsif ast.type == :COLON2
-              name = ast.children[1].to_s
-              "#{from_ast(ast.children[0])}::#{name}"
+            until ast.nil?
+              if ast.is_a? ::Parser::AST::Node
+                break unless ast.type == :const
+
+                parts << ast.children[1]
+                ast = ast.children[0]
+              else
+                parts << ast
+                break
+              end
             end
+
+            parts.reverse.join('::')
           end
 
           def from_context_block_ast(block_ast)

--- a/lib/solargraph/rspec/spec_walker/node_types.rb
+++ b/lib/solargraph/rspec/spec_walker/node_types.rb
@@ -4,78 +4,71 @@ module Solargraph
   module Rspec
     class SpecWalker
       class NodeTypes
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @return [Boolean]
         def self.a_block?(ast)
-          return false unless ast.is_a?(RubyVM::AbstractSyntaxTree::Node)
-
-          %i[ITER LAMBDA].include?(ast.type)
+          ast.is_a?(::Parser::AST::Node) && ast.type == :block
         end
 
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @return [Boolean]
         def self.a_context_block?(block_ast)
           Solargraph::Rspec::CONTEXT_METHODS.include?(method_with_block_name(block_ast))
         end
 
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @return [Boolean]
         def self.a_subject_block?(block_ast)
           Solargraph::Rspec::SUBJECT_METHODS.include?(method_with_block_name(block_ast))
         end
 
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @param config [Config]
         # @return [Boolean]
         def self.a_example_block?(block_ast, config)
           config.example_methods.map(&:to_s).include?(method_with_block_name(block_ast))
         end
 
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @param config [Config]
         # @return [Boolean]
         def self.a_let_block?(block_ast, config)
           config.let_methods.map(&:to_s).include?(method_with_block_name(block_ast))
         end
 
-        # @param ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param ast [::Parser::AST::Node]
         # @return [Boolean]
         def self.a_hook_block?(block_ast)
           Solargraph::Rspec::HOOK_METHODS.include?(method_with_block_name(block_ast))
         end
 
         def self.a_constant?(ast)
-          %i[CONST COLON2].include?(ast.type)
+          ast.type == :const
         end
 
-        # @param block_ast [RubyVM::AbstractSyntaxTree::Node]
-        # @return [String, nil]
+        # @param block_ast [::Parser::AST::Node]
+        # @return [String, nil] The name of the thing you are calling the block on
         def self.method_with_block_name(block_ast)
           return nil unless a_block?(block_ast)
+          return nil unless block_ast.children[0].type == :send
 
-          method_call = %i[CALL FCALL].include?(block_ast.children[0].type)
-          return nil unless method_call
-
-          block_ast.children[0].children.select { |child| child.is_a?(Symbol) }.first&.to_s
+          block_ast.children[0].children[1].to_s
         end
 
-        # @param block_ast [RubyVM::AbstractSyntaxTree::Node]
-        # @return [RubyVM::AbstractSyntaxTree::Node]
+        # @param block_ast [::Parser::AST::Node]
+        # @return [::Parser::AST::Node]
         def self.context_description_node(block_ast)
           return nil unless a_context_block?(block_ast)
 
-          case block_ast.children[0].type
-          when :CALL # RSpec.describe "something" do end
-            block_ast.children[0].children[2].children[0]
-          when :FCALL # describe "something" do end
-            block_ast.children[0].children[1].children[0]
-          end
+          block_ast.children[0].children[2]
         end
 
-        # @param block_ast [RubyVM::AbstractSyntaxTree::Node]
+        # @param block_ast [::Parser::AST::Node]
         # @return [String]
         def self.let_method_name(block_ast)
-          block_ast.children[0].children[1]&.children&.[](0)&.children&.[](0)&.to_s # rubocop:disable Style/SafeNavigationChainLength
+          return nil unless a_block?(block_ast)
+
+          block_ast.children[0].children[2]&.children&.[](0)&.to_s # rubocop:disable Style/SafeNavigationChainLength
         end
       end
     end

--- a/lib/solargraph/rspec/spec_walker/rspec_context_namespace.rb
+++ b/lib/solargraph/rspec/spec_walker/rspec_context_namespace.rb
@@ -5,13 +5,13 @@ module Solargraph
     class SpecWalker
       class RspecContextNamespace
         class << self
-          # @param block_ast [RubyVM::AbstractSyntaxTree::Node]
+          # @param block_ast [::Parser::AST::Node]
           # @return [String, nil]
           def from_block_ast(block_ast)
-            return unless block_ast.is_a?(RubyVM::AbstractSyntaxTree::Node)
+            return unless block_ast.is_a?(::Parser::AST::Node)
 
             ast = NodeTypes.context_description_node(block_ast)
-            if ast.type == :STR
+            if ast.type == :str
               string_to_const_name(ast)
             elsif NodeTypes.a_constant?(ast)
               FullConstantName.from_ast(ast).gsub('::', '')
@@ -27,7 +27,7 @@ module Solargraph
           # @param ast [Parser::AST::Node]
           # @return [String]
           def string_to_const_name(string_ast)
-            return unless string_ast.type == :STR
+            return unless string_ast.type == :str
 
             name = string_ast.children[0]
             return 'Anonymous'.dup if name.empty?

--- a/lib/solargraph/rspec/walker.rb
+++ b/lib/solargraph/rspec/walker.rb
@@ -17,7 +17,7 @@ module Solargraph
           @proc = Proc.new(&block)
         end
 
-        # @param node [RubyVM::AbstractSyntaxTree::Node]
+        # @param node [::Parser::AST::Node]
         # @return [void]
         def visit(node)
           return unless matches?(node)
@@ -33,15 +33,15 @@ module Solargraph
 
         private
 
-        # @param node [RubyVM::AbstractSyntaxTree::Node]
+        # @param node [::Parser::AST::Node]
         # @return [Boolean]
         def matches?(node)
           return false unless node.type == node_type
           return false unless node.children
           return true if @args.empty?
 
-          a_child_matches = node.children.first.is_a?(RubyVM::AbstractSyntaxTree::Node) && node.children.any? do |child|
-            child.is_a?(RubyVM::AbstractSyntaxTree::Node) &&
+          a_child_matches = node.children.first.is_a?(::Parser::AST::Node) && node.children.any? do |child|
+            child.is_a?(::Parser::AST::Node) &&
               match_children(child.children, @args[1..])
           end
 
@@ -50,12 +50,12 @@ module Solargraph
           match_children(node.children)
         end
 
-        # @param children [Array<RubyVM::AbstractSyntaxTree::Node>]
+        # @param children [Array<::Parser::AST::Node>]
         def match_children(children, args = @args)
           args.each_with_index.all? do |arg, i|
             if arg == :any
               true
-            elsif children[i].is_a?(RubyVM::AbstractSyntaxTree::Node) && arg.is_a?(Symbol)
+            elsif children[i].is_a?(::Parser::AST::Node) && arg.is_a?(Symbol)
               children[i].type == arg
             else
               children[i] == arg
@@ -66,7 +66,7 @@ module Solargraph
 
       attr_reader :ast, :comments
 
-      # @param ast [RubyVM::AbstractSyntaxTree::Node]
+      # @param ast [::Parser::AST::Node]
       # @param comments [Hash]
       def initialize(ast, comments = {})
         @comments = comments
@@ -74,6 +74,8 @@ module Solargraph
         @hooks = Hash.new { |h, k| h[k] = [] }
       end
 
+      # @yieldparam [::Parser::AST::Node]
+      # @yieldparam [Walker]
       def on(node_type, args = [], &block)
         @hooks[node_type] << Hook.new(node_type, args, &block)
       end
@@ -85,7 +87,7 @@ module Solargraph
       private
 
       def traverse(node)
-        return unless node.is_a?(RubyVM::AbstractSyntaxTree::Node)
+        return unless node.is_a?(::Parser::AST::Node)
 
         @hooks[node.type].each { |hook| hook.visit(node) }
 

--- a/spec/solargraph/rspec/spec_walker/node_types_spec.rb
+++ b/spec/solargraph/rspec/spec_walker/node_types_spec.rb
@@ -2,25 +2,25 @@
 
 RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
   def parse(code)
-    RubyVM::AbstractSyntaxTree.parse(code)
+    Solargraph::Parser.parse(code)
   end
 
   describe '.a_block?' do
     it 'returns true for block nodes' do
       node = parse('describe "something" do end')
-      expect(described_class.a_block?(node.children[2])).to be(true)
+      expect(described_class.a_block?(node)).to be(true)
     end
 
     it 'returns false for non-block nodes' do
       node = parse('describe "something"')
-      expect(described_class.a_block?(node.children[2])).to be(false)
+      expect(described_class.a_block?(node)).to be(false)
     end
   end
 
   describe '.a_context_block?' do
     it 'returns true for RSpec context block nodes' do
       node = parse('describe "something" do end')
-      expect(described_class.a_context_block?(node.children[2])).to be(true)
+      expect(described_class.a_context_block?(node)).to be(true)
     end
 
     it 'returns true for RSpec root context block nodes' do
@@ -29,30 +29,30 @@ RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
         end
       RUBY
 
-      expect(described_class.a_context_block?(node.children[2])).to be(true)
+      expect(described_class.a_context_block?(node)).to be(true)
     end
 
     it 'returns false for non-RSpec context block nodes' do
       node = parse('different_context "something" do end')
-      expect(described_class.a_context_block?(node.children[2])).to be(false)
+      expect(described_class.a_context_block?(node)).to be(false)
     end
   end
 
   describe '.a_subject_block?' do
     it 'returns true for subject block with name' do
       node = parse('subject(:something) { }')
-      expect(described_class.a_subject_block?(node.children[2])).to be(true)
+      expect(described_class.a_subject_block?(node)).to be(true)
     end
 
     it 'returns true for subject block without name' do
       node = parse('subject { }')
 
-      expect(described_class.a_subject_block?(node.children[2])).to be(true)
+      expect(described_class.a_subject_block?(node)).to be(true)
     end
 
     it 'returns false for non-subject block' do
       node = parse('non_subject { }')
-      expect(described_class.a_subject_block?(node.children[2])).to be(false)
+      expect(described_class.a_subject_block?(node)).to be(false)
     end
   end
 
@@ -61,36 +61,36 @@ RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
 
     it 'returns true for example block with name' do
       node = parse('it("does something") { }')
-      expect(described_class.a_example_block?(node.children[2], config)).to be(true)
+      expect(described_class.a_example_block?(node, config)).to be(true)
     end
 
     it 'returns true for example block without name' do
       node = parse('it { }')
-      expect(described_class.a_example_block?(node.children[2], config)).to be(true)
+      expect(described_class.a_example_block?(node, config)).to be(true)
     end
 
     it 'returns false for non-example block' do
       node = parse('non_example { }')
-      expect(described_class.a_example_block?(node.children[2], config)).to be(false)
+      expect(described_class.a_example_block?(node, config)).to be(false)
     end
   end
 
   describe '.a_hook_block?' do
     it 'returns true for example block with name' do
       node = parse('before { }')
-      expect(described_class.a_hook_block?(node.children[2])).to be(true)
+      expect(described_class.a_hook_block?(node)).to be(true)
     end
 
     it 'returns false for non-hook block' do
       node = parse('non_hook { }')
-      expect(described_class.a_hook_block?(node.children[2])).to be(false)
+      expect(described_class.a_hook_block?(node)).to be(false)
     end
   end
 
   describe '.context_description_node' do
     it 'returns correct node of context description' do
       node = parse('describe "something" do end')
-      desc = described_class.context_description_node(node.children[2])
+      desc = described_class.context_description_node(node)
       expect(desc.children.first).to eq('something')
     end
 
@@ -100,13 +100,13 @@ RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
         end
       RUBY
 
-      desc = described_class.context_description_node(node.children[2])
+      desc = described_class.context_description_node(node)
       expect(desc.children.last).to eq(:SomeClass)
     end
 
     it 'returns nil for non-context block' do
       node = parse('non_context "something" do end')
-      desc = described_class.context_description_node(node.children[2])
+      desc = described_class.context_description_node(node)
       expect(desc).to eq(nil)
     end
   end
@@ -114,25 +114,25 @@ RSpec.describe Solargraph::Rspec::SpecWalker::NodeTypes do
   describe '.let_method_name' do
     it 'returns correct method name for subject block' do
       node = parse('subject(:something) { }')
-      name = described_class.let_method_name(node.children[2])
+      name = described_class.let_method_name(node)
       expect(name).to eq('something')
     end
 
     it 'returns nil for subject block without a name' do
       node = parse('subject { }')
-      name = described_class.let_method_name(node.children[2])
+      name = described_class.let_method_name(node)
       expect(name).to eq(nil)
     end
 
     it 'returns correct method name for let block' do
       node = parse('let(:something) { }')
-      name = described_class.let_method_name(node.children[2])
+      name = described_class.let_method_name(node)
       expect(name).to eq('something')
     end
 
     it 'returns nil for let block without a name' do
       node = parse('let { }')
-      name = described_class.let_method_name(node.children[2])
+      name = described_class.let_method_name(node)
       expect(name).to eq(nil)
     end
   end

--- a/spec/solargraph/rspec/spec_walker_spec.rb
+++ b/spec/solargraph/rspec/spec_walker_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Solargraph::Rspec::SpecWalker do
   let(:source_map) { api_map.source_maps.first }
 
   def parse_expected_let_method(code)
-    # TODO: Replace with Solargraph::Parser::ParserGem.parse(code) after solargraph gem release >0.52.0
-    Parser::CurrentRuby.parse(code)
+    Solargraph::Parser.parse(code)
   end
 
   # @param code [String]


### PR DESCRIPTION
Refactor (again?) to use solargraph's parser. Performance reasons mentioned in the RubyVM issue have been resolved (esepcially in latest version, which uses prism too)

This might actually improve performance since you wouldn't be re-parsing anything in the spec walker, but I haven't benchmarked anything