### PR TITLE
Add support for RSpec.shared_examples

### DIFF
--- a/lib/solargraph/rspec/convention.rb
+++ b/lib/solargraph/rspec/convention.rb
@@ -9,6 +9,7 @@ require_relative 'correctors/described_class_corrector'
 require_relative 'correctors/let_methods_corrector'
 require_relative 'correctors/subject_method_corrector'
 require_relative 'correctors/dsl_methods_corrector'
+require_relative 'correctors/shared_examples_corrector'
 require_relative 'test_helpers'
 require_relative 'pin_factory'
 
@@ -33,6 +34,15 @@ module Solargraph
       pending
     ].freeze
 
+    SHARED_EXAMPLE_INCLUSION_METHODS = %w[
+      include_examples
+      it_behaves_like
+      it_should_behave_like
+      include_context
+    ].freeze
+
+    SHARED_EXAMPLE_DEFINITION_METHODS = %w[shared_examples shared_examples_for shared_context].freeze
+
     CONTEXT_METHODS = %w[
       example_group
       describe
@@ -42,12 +52,8 @@ module Solargraph
       fdescribe
       fcontext
       shared_examples
-      include_examples
-      it_behaves_like
-      it_should_behave_like
       shared_context
-      include_context
-    ].freeze
+    ].freeze + SHARED_EXAMPLE_INCLUSION_METHODS
 
     # @type [Array<Class<Correctors::Base>>]
     CORRECTOR_CLASSES = [
@@ -56,7 +62,8 @@ module Solargraph
       Correctors::DslMethodsCorrector,
       Correctors::ExampleAndHookBlocksBindingCorrector,
       Correctors::LetMethodsCorrector,
-      Correctors::SubjectMethodCorrector
+      Correctors::SubjectMethodCorrector,
+      Correctors::SharedExamplesCorrector
     ].freeze
 
     # Provides completion for RSpec DSL and helper methods.

--- a/lib/solargraph/rspec/correctors/shared_examples_corrector.rb
+++ b/lib/solargraph/rspec/correctors/shared_examples_corrector.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Solargraph
+  module Rspec
+    module Correctors
+      class SharedExamplesCorrector < Base
+        # @param source_map [Solargraph::SourceMap]
+        def correct(source_map)
+          @shared_examples = {}
+
+          rspec_walker.on_shared_example_definition do |shared_examples_name, location_range|
+            SHARED_EXAMPLE_INCLUSION_METHODS.each do |method_name|
+              pin = Solargraph::Pin::FactoryParameter.new(
+                method_name: method_name,
+                method_namespace: 'RSpec::Core::ExampleGroup',
+                method_scope: :class,
+                param_name: 'name',
+                value: shared_examples_name,
+                return_type: nil,
+                decl: :arg,
+                location: PinFactory.build_location(location_range, source_map.source.filename)
+              )
+              add_pin(pin)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/rspec/spec_walker/node_types.rb
+++ b/lib/solargraph/rspec/spec_walker/node_types.rb
@@ -70,6 +70,28 @@ module Solargraph
 
           block_ast.children[0].children[2]&.children&.[](0)&.to_s # rubocop:disable Style/SafeNavigationChainLength
         end
+
+        # @param block_ast [::Parser::AST::Node]
+        # @return [Boolean]
+        def self.a_shared_example_definition?(block_ast)
+          SHARED_EXAMPLE_DEFINITION_METHODS.include?(method_with_block_name(block_ast))
+        end
+
+        # @param block_ast [::Parser::AST::Node]
+        # @return [String, Symbol, nil] The name of the shared example being defined or included
+        def self.shared_example_name(block_ast)
+          return nil unless a_shared_example_definition?(block_ast)
+
+          name_node = block_ast.children[0].children[2]
+          return nil unless name_node
+
+          case name_node.type
+          when :str, :dstr
+            name_node.children[0]&.to_s
+          when :sym
+            name_node.children[0]
+          end
+        end
       end
     end
   end

--- a/spec/solargraph/rspec/shared_example_definition_spec.rb
+++ b/spec/solargraph/rspec/shared_example_definition_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+RSpec.describe Solargraph::Rspec::Convention do
+  let(:api_map) { Solargraph::ApiMap.new }
+  let(:library) { Solargraph::Library.new }
+  let(:filename) { File.expand_path('spec/models/shared_examples_spec.rb') }
+
+  describe 'shared examples support' do
+    it 'provides completion for shared example names in include_examples' do
+      load_string filename, <<~RUBY
+        RSpec.shared_examples 'a shared example' do
+          it 'does something' do
+            expect(true).to eq(true)
+          end
+        end
+
+        RSpec.shared_examples 'another shared example' do
+          it 'does something else' do
+            expect(false).to eq(false)
+          end
+        end
+
+        RSpec.describe SomeClass do
+          include_examples 'a shared example'
+        end
+      RUBY
+
+      # Check that factory parameters are created for shared examples
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      shared_example_params = factory_params.select do |pin|
+        pin.method_name == 'include_examples' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(shared_example_params.map(&:value)).to include('a shared example', 'another shared example')
+    end
+
+    it 'provides completion for shared example names in it_behaves_like' do
+      load_string filename, <<~RUBY
+        RSpec.shared_examples 'behaves like something' do
+          it 'has behavior' do
+            expect(subject).to be_truthy
+          end
+        end
+
+        RSpec.describe SomeClass do
+          it_behaves_like 'behaves like something'
+        end
+      RUBY
+
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      behaves_like_params = factory_params.select do |pin|
+        pin.method_name == 'it_behaves_like' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(behaves_like_params.map(&:value)).to include('behaves like something')
+    end
+
+    it 'provides completion for shared example names in it_should_behave_like' do
+      load_string filename, <<~RUBY
+        RSpec.shared_examples 'legacy behavior' do
+          it 'works with old syntax' do
+            expect(1).to eq(1)
+          end
+        end
+
+        RSpec.describe SomeClass do
+          it_should_behave_like 'legacy behavior'
+        end
+      RUBY
+
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      should_behave_params = factory_params.select do |pin|
+        pin.method_name == 'it_should_behave_like' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(should_behave_params.map(&:value)).to include('legacy behavior')
+    end
+
+    it 'supports shared_context and include_context' do
+      load_string filename, <<~RUBY
+        RSpec.shared_context 'with setup' do
+          let(:value) { 42 }
+        end
+
+        RSpec.describe SomeClass do
+          include_context 'with setup'
+        end
+      RUBY
+
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      context_params = factory_params.select do |pin|
+        pin.method_name == 'include_context' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(context_params.map(&:value)).to include('with setup')
+    end
+
+    it 'handles shared examples with symbols' do
+      load_string filename, <<~RUBY
+        RSpec.shared_examples :symbol_example do
+          it 'works with symbols' do
+            expect(true).to be true
+          end
+        end
+
+        RSpec.describe SomeClass do
+          include_examples :symbol_example
+        end
+      RUBY
+
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      symbol_params = factory_params.select do |pin|
+        pin.method_name == 'include_examples' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(symbol_params.map(&:value)).to include(:symbol_example)
+    end
+
+    it 'works with shared_examples_for alias' do
+      load_string filename, <<~RUBY
+        RSpec.shared_examples_for 'aliased example' do
+          it 'uses the alias' do
+            expect(42).to eq(42)
+          end
+        end
+
+        RSpec.describe SomeClass do
+          include_examples 'aliased example'
+        end
+      RUBY
+
+      factory_params = api_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::FactoryParameter) }
+
+      alias_params = factory_params.select do |pin|
+        pin.method_name == 'include_examples' &&
+          pin.method_namespace == 'RSpec::Core::ExampleGroup' &&
+          pin.method_scope == :class
+      end
+
+      expect(alias_params.map(&:value)).to include('aliased example')
+    end
+  end
+end

--- a/spec/support/solargraph_helpers.rb
+++ b/spec/support/solargraph_helpers.rb
@@ -66,6 +66,7 @@ module SolargraphHelpers
     cursor = clip.send(:cursor)
     word = cursor.chain.links.first.word
 
+    # puts "Completion: word=#{word}, links=#{cursor.chain.links}"
     Solargraph.logger.debug(
       "Complete: word=#{word}, links=#{cursor.chain.links}"
     )
@@ -75,6 +76,20 @@ module SolargraphHelpers
 
   def completion_at(filename, position, map = api_map)
     completion_pins_at(filename, position, map).map(&:name)
+  end
+
+  def defintion_pins_at(filename, position, map = api_map)
+    # @type [Solargraph::SourceMap::Clip]
+    clip = map.clip_at(filename, position)
+    cursor = clip.send(:cursor)
+    word = cursor.chain.links.first.word
+
+    # puts "Definition: word=#{word}, links=#{cursor.chain.links}"
+    Solargraph.logger.debug(
+      "Definition: word=#{word}, links=#{cursor.chain.links}"
+    )
+
+    clip.define
   end
 
   # Expect that a local can be inferred with +expected_type+


### PR DESCRIPTION
https://rspec.info/features/3-13/rspec-core/example-groups/shared-examples/

Depends on: https://github.com/castwide/solargraph/pull/1063 (required) and https://github.com/castwide/solargraph/pull/1028 (optional but desired, we can mark the failing spec as pending)