### PR TITLE
Fix breaking of solargraph rubocop diagnostics

### DIFF
--- a/lib/solargraph/rspec/spec_walker/rspec_context_namespace.rb
+++ b/lib/solargraph/rspec/spec_walker/rspec_context_namespace.rb
@@ -11,6 +11,8 @@ module Solargraph
             return unless block_ast.is_a?(::Parser::AST::Node)
 
             ast = NodeTypes.context_description_node(block_ast)
+            return unless ast
+
             if ast.type == :str
               string_to_const_name(ast)
             elsif NodeTypes.a_constant?(ast)


### PR DESCRIPTION
```
[ERROR][2025-09-05 14:24:44] ...p/_transport.lua:36 "rpc" "solargraph"
"stderr" "[WARN] [RSpec] Error processing
/Users/lekemula/Projects/solargraph/spec/diagnostics/rubocop_helpers_spec.rb:
undefined method type' for
nil\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker/rspec_context_namespace.rb:14:in
from_block_ast'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:199:in
block in
each_context_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:183:in
each_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
block in
each_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
each'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
each_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
block in
each_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
each'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:187:in
each_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:194:in
each_context_block'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/spec_walker.rb:100:in
walk!'\n/Users/lekemula/.rvm/gems/ruby-3.3.1/gems/solargraph-rspec-0.5.3/lib/solargraph/rspec/convention.rb:132:in
local'\n/Users/lekemula/Projects/solargraph/lib/solargraph/convention.rb:36:in
block in
for_local'\n/Users/lekemula/.rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/set.rb:501:in
each_key'\n/Users/lekemula/.rvm/rubies/ruby-3.3.1/lib/ruby/3.3.0/set.rb:501:in
each'\n/Users/lekemula/Projects/solargraph/lib/solargraph/convention.rb:35:in
for_local'\n/Users/lekemula/Projects/solargraph/lib/solargraph/source_map.rb:33:in
initialize'\n/Users/lekemula/Projects/solargraph/lib/solargraph/source_map.rb:157:in
new'\n/Users/lekemula/Projects/solargraph/lib/solargraph/source_map.rb:157:in
map'\n/Users/lekemula/Projects/solargraph/lib/solargraph/library.rb:475:in
next_map'\n/Users/lekemula/Projects/solargraph/lib/solargraph/language_server/host.rb:862:in
sync_library_map'\n/Users/lekemula/Projects/solargraph/lib/solargraph/language_server/host.rb:851:in
`block in library_map'\n"
```