### PR TITLE
Fix upcoming spec incompatibility with solargraph ApiMap

### DIFF
--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe Solargraph::Rspec::Convention do
   let(:library) { Solargraph::Library.new }
   let(:filename) { File.expand_path('spec/models/some_namespace/transaction_spec.rb') }
 
-  before do
-    # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
-    # If your specs depend on YARDoc or RBS types, add them to the spec/solargraph/rspec/first_party_gem_helpers_spec.rb
-    avoid_gem_yard_and_rbs_pin_generation
-  end
-
   it 'generates method for described_class' do
     load_string filename, <<~RUBY
       RSpec.describe SomeNamespace::Transaction, type: :model do

--- a/spec/solargraph/rspec/spec_walker_spec.rb
+++ b/spec/solargraph/rspec/spec_walker_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe Solargraph::Rspec::SpecWalker do
   let(:config) { Solargraph::Rspec::Config.new }
   let(:source_map) { api_map.source_maps.first }
 
-  before do
-    # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
-    avoid_gem_yard_and_rbs_pin_generation
-  end
-
   def parse_expected_let_method(code)
     Solargraph::Parser.parse(code)
   end

--- a/spec/support/solargraph_helpers.rb
+++ b/spec/support/solargraph_helpers.rb
@@ -92,10 +92,4 @@ module SolargraphHelpers
 
     var_pin
   end
-
-  # For performance reasons, avoid solargraph loading all installed gems' YARDoc and RBS gem pins.
-  # @return [void]
-  def avoid_gem_yard_and_rbs_pin_generation
-    allow(Solargraph::Rspec::Gems).to receive(:gem_names).and_return([])
-  end
 end


### PR DESCRIPTION
In an upcoming solargraph PR (see https://github.com/castwide/solargraph/pull/1107 as an example), we won't be able to rely on resolving RSpec constants whose gem names we don't provide using the 'require' convention.

That said, we also should not be caching as aggressively in solargraph, either - so I'd recommend dropping this spec workaround, which seems to resolve the issue seen in the PR above.