### PR TITLE
More reliable closure and location updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
           set -x
 
-          rspec_gems=$(ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+          rspec_gems=$(ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
           echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,9 +74,10 @@ jobs:
 
       - name: Solargraph generate RSpec gems YARD and RBS pins
         run: |
+          set -euo pipefail
           set -x
 
-          rspec_gems=$(bundle exec appraisal ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+          rspec_gems=$(ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
           echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
           set -x
 
-          bundle ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
+          bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
           rspec_gems=$(bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
           echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           rubygems: latest
-          bundler: latest
           bundler-cache: false
 
       - name: Cache Ruby gems
@@ -76,14 +75,8 @@ jobs:
 
       - name: Solargraph generate RSpec gems YARD and RBS pins
         run: |
-          set -euo pipefail
-          set -x
-
-          bundle list
-          bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
-          rspec_gems=$(bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
-          echo "rspec_gems is [$rspec_gems]"
-          bundle exec appraisal solargraph gems $rspec_gems
+          rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+          bundle exec appraisal bundle exec solargraph gems $rspec_gems
 
       - name: Run tests
         run: bundle exec appraisal rspec --format progress

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,7 +74,10 @@ jobs:
 
       - name: Solargraph generate RSpec gems YARD and RBS pins
         run: |
+          set -x
+
           rspec_gems=$(bundle exec appraisal ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+          echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems
 
       - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Solargraph generate RSpec gems YARD and RBS pins
         run: |
-          rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+          rspec_gems=$(bundle exec appraisal ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
           bundle exec appraisal solargraph gems $rspec_gems
 
       - name: Run tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: Gemfile.lock
+          bundler: latest
           bundler-cache: false
 
       - name: Cache Ruby gems

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: latest
           bundler: latest
           bundler-cache: false
 
@@ -78,6 +79,7 @@ jobs:
           set -euo pipefail
           set -x
 
+          bundle list
           bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
           rspec_gems=$(bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
           echo "rspec_gems is [$rspec_gems]"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -77,8 +77,8 @@ jobs:
           set -euo pipefail
           set -x
 
-          ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
-          rspec_gems=$(ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
+          bundle ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
+          rspec_gems=$(bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
           echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         # FIXME: Why '3.0' is not working with Appraisal?
-        # FIXME: Add 'head' https://github.com/lekemula/solargraph-rspec/pull/8/commits/3b52752b96e7f2ec01831406f8e5a51c91523187 
+        # FIXME: Add 'head' https://github.com/lekemula/solargraph-rspec/pull/8/commits/3b52752b96e7f2ec01831406f8e5a51c91523187
         ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
@@ -75,7 +75,7 @@ jobs:
       - name: Solargraph generate RSpec gems YARD and RBS pins
         run: |
           rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
-          bundle exec appraisal bundle exec solargraph gems $rspec_gems
+          bundle exec appraisal solargraph gems $rspec_gems
 
       - name: Run tests
         run: bundle exec appraisal rspec --format progress

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler: Gemfile.lock
           bundler-cache: false
 
       - name: Cache Ruby gems

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -77,6 +77,7 @@ jobs:
           set -euo pipefail
           set -x
 
+          ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")'
           rspec_gems=$(ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null)
           echo "rspec_gems is [$rspec_gems]"
           bundle exec appraisal solargraph gems $rspec_gems

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Contributing is easy - note that this Gem uses 'appraisal' to test against RSpec
    bundle exec appraisal install
    cp .solargraph.yml.example .solargraph.yml
    bundle exec appraisal bundle exec rbs collection update
-    rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+   rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
    bundle exec appraisal bundle exec solargraph gems $rspec_gems
    bundle exec appraisal rspec
    ```

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Contributing is easy - note that this Gem uses 'appraisal' to test against RSpec
    bundle exec appraisal install
    cp .solargraph.yml.example .solargraph.yml
    bundle exec appraisal bundle exec rbs collection update
-   rspec_gems=$(bundle exec appraisal ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
-   bundle exec appraisal solargraph gems $rspec_gems
+    rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+   bundle exec appraisal bundle exec solargraph gems $rspec_gems
    bundle exec appraisal rspec
    ```
 3. Introduce your awesome changes

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Contributing is easy - note that this Gem uses 'appraisal' to test against RSpec
    bundle exec appraisal install
    cp .solargraph.yml.example .solargraph.yml
    bundle exec appraisal bundle exec rbs collection update
-   rspec_gems=$(bundle exec appraisal bundle exec ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
-   bundle exec appraisal bundle exec solargraph gems $rspec_gems
+   rspec_gems=$(bundle exec appraisal ruby -r './lib/solargraph-rspec' -e 'puts Solargraph::Rspec::Gems.gem_names.join(" ")' 2>/dev/null | tail -n1)
+   bundle exec appraisal solargraph gems $rspec_gems
    bundle exec appraisal rspec
    ```
 3. Introduce your awesome changes

--- a/lib/solargraph/rspec/correctors/base.rb
+++ b/lib/solargraph/rspec/correctors/base.rb
@@ -119,9 +119,7 @@ module Solargraph
 
           # find children of this pin and reset them, as they may have
           # cached their binder or context based on the old closure
-          source_map.pins.each do |child_pin|
-            next unless child_pin.closure == closure
-
+          source_map.pins.select { |child_pin| child_pin.closure == closure }.each do |child_pin|
             child_pin.reset_generated!
           end
         end

--- a/lib/solargraph/rspec/correctors/base.rb
+++ b/lib/solargraph/rspec/correctors/base.rb
@@ -68,7 +68,12 @@ module Solargraph
         # @param pin [Solargraph::Pin::Base]
         # @param new_closure [Solargraph::Pin::Closure]
         def override_closure(pin, new_closure)
-          # HACK: We should only rely on public API, and avoid instance_variable_get/set.
+          if pin.respond_to?(:closure=)
+            pin.closure = new_closure
+            return
+          end
+
+          # work around older version of Solargraph
           pin.instance_variable_set('@closure', new_closure)
           pin.reset_generated!
 
@@ -104,8 +109,21 @@ module Solargraph
             closure.location.filename
           )
 
-          # HACK: We should only rely on public API, and avoid instance_variable_get/set.
-          closure.instance_variable_set('@location', new_location)
+          if closure.respond_to?(:location=)
+            closure.location = new_location
+          else
+            # work around older version of Solargraph
+            closure.instance_variable_set('@location', new_location)
+            closure.reset_generated!
+          end
+
+          # find children of this pin and reset them, as they may have
+          # cached their binder or context based on the old closure
+          source_map.pins.each do |child_pin|
+            next unless child_pin.closure == closure
+
+            child_pin.reset_generated!
+          end
         end
       end
     end


### PR DESCRIPTION
This addresses a spec failure seen with https://github.com/castwide/solargraph/pull/1116 by using a new public interface and updating other pins affected by the location updates being done.

See failure here: https://github.com/castwide/solargraph/actions/runs/19284016909/job/55140836730?pr=1116

