### PR TITLE
Avoid inference from literal values

### DIFF
--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -433,8 +433,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     end
 
     it 'infers type for some_nil' do
-      skip 'FIXME: Not sure that this inference is necessary'
-      load_and_assert_type('let(:some_nil) { nil }', 'some_nil', 'NilClass')
+      load_and_assert_type('let(:some_nil) { nil }', 'some_nil', 'nil')
     end
 
     it 'infers type for some_float' do

--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     end
 
     it 'infers type for some_array' do
-      load_and_assert_type('let(:some_array) { [1, 2, 3] }', 'some_array', 'Array<Integer>')
+      load_and_assert_type('let(:some_array) { [1, 2, 3] }', 'some_array', 'Array')
     end
 
     it 'infers type for some_hash' do
@@ -433,6 +433,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     end
 
     it 'infers type for some_nil' do
+      skip 'FIXME: Not sure that this inference is necessary'
       load_and_assert_type('let(:some_nil) { nil }', 'some_nil', 'NilClass')
     end
 
@@ -533,7 +534,7 @@ RSpec.describe Solargraph::Rspec::Convention do
       assert_public_instance_method_inferred_type(
         api_map,
         'RSpec::ExampleGroups::TestSomeNamespaceTransaction#some_array',
-        'Array<Integer>'
+        'Array'
       )
       assert_public_instance_method_inferred_type(
         api_map,


### PR DESCRIPTION
Two type assertion specs are failing for castwide/solargraph#1201 because we're no longer inferring array parameters from literal values.

I'm not completely sure about the `some_nil` test. It doesn't seem strictly necessary as long as the maps recognize `nil` as a singleton instance of `NilClass`.