### PR TITLE
Tolerate more precise Hash and Array literal type inference

### DIFF
--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     assert_public_instance_method_inferred_type(
       api_map,
       'RSpec::ExampleGroups::TestSomeNamespaceTransaction#todo',
-      'Hash'
+      ['Hash', 'Hash{String => String}']
     )
   end
 
@@ -425,7 +425,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     end
 
     it 'infers type for some_hash' do
-      load_and_assert_type("let(:some_hash) { { key: 'value' } }", 'some_hash', 'Hash')
+      load_and_assert_type("let(:some_hash) { { key: 'value' } }", 'some_hash', ['Hash', 'Hash{Symbol => String}'])
     end
 
     it 'infers type for some_boolean' do
@@ -538,7 +538,7 @@ RSpec.describe Solargraph::Rspec::Convention do
       assert_public_instance_method_inferred_type(
         api_map,
         'RSpec::ExampleGroups::TestSomeNamespaceTransaction#some_hash',
-        'Hash'
+        ['Hash', 'Hash{Symbol => String}']
       )
       assert_public_instance_method_inferred_type(
         api_map,

--- a/spec/solargraph/rspec/convention_spec.rb
+++ b/spec/solargraph/rspec/convention_spec.rb
@@ -421,7 +421,7 @@ RSpec.describe Solargraph::Rspec::Convention do
     end
 
     it 'infers type for some_array' do
-      load_and_assert_type('let(:some_array) { [1, 2, 3] }', 'some_array', 'Array')
+      load_and_assert_type('let(:some_array) { [1, 2, 3] }', 'some_array', ['Array', 'Array<Integer>'])
     end
 
     it 'infers type for some_hash' do
@@ -533,7 +533,7 @@ RSpec.describe Solargraph::Rspec::Convention do
       assert_public_instance_method_inferred_type(
         api_map,
         'RSpec::ExampleGroups::TestSomeNamespaceTransaction#some_array',
-        'Array'
+        ['Array', 'Array<Integer>']
       )
       assert_public_instance_method_inferred_type(
         api_map,

--- a/spec/support/solargraph_helpers.rb
+++ b/spec/support/solargraph_helpers.rb
@@ -33,13 +33,17 @@ module SolargraphHelpers
     yield pin if block_given?
   end
 
+  # return_type may be one accepted inferred-type string, or several -
+  # lets a spec pass against both a Solargraph release and a checkout
+  # with a not-yet-released literal-inference improvement, without
+  # requiring the improvement to be merged first.
   def assert_public_instance_method_inferred_type(map, query, return_type)
     pin = find_pin(query, map)
     expect(pin).to_not be_nil, "Method #{query} not found"
     expect(pin.scope).to eq(:instance)
     inferred_return_type = pin.probe(api_map).simplify_literals.to_s
 
-    expect(inferred_return_type).to eq(return_type)
+    expect(Array(return_type)).to include(inferred_return_type)
 
     yield pin if block_given?
   end


### PR DESCRIPTION
**Claude:** opened on behalf of Vince Broz.

Problem:

These five specs assert one exact inferred-type string ('Hash' or
'Array'), so each one fails the moment a Solargraph version infers
the more precise Hash{Symbol => String} / Array<Integer> for the
same literal.

    assert_public_instance_method_inferred_type(
      api_map,
      '...#some_array',
      'Array'
    )
    # expected ["Array"] to include "Array<Integer>"

Since this plugin supports Solargraph >= 0.52.0 with no upper
bound, an assertion pinned to one exact string cannot hold across
that whole range once a version with this precision exists.

Solution:

Let assert_public_instance_method_inferred_type (and
load_and_assert_type, which forwards to it) accept either a single
expected type string or an array of acceptable ones, and update
all five affected Hash- and Array-literal assertions to list both
the old and the more precise type.
